### PR TITLE
Fix doctor check encoding

### DIFF
--- a/x987_v3/x987/doctor.py
+++ b/x987_v3/x987/doctor.py
@@ -11,4 +11,4 @@ def doctor_check() -> None:
     python -m playwright install chromium
 '''.strip())
         raise
-    print('âœ… Doctor OK')
+    print('✅ Doctor OK')


### PR DESCRIPTION
## Summary
- fix doctor message string in `doctor_check`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a606158d208328b4512e8db700ae53