### PR TITLE
Improve mileage parsing for 'k' suffix

### DIFF
--- a/x987_v3/tests/test_parse_miles.py
+++ b/x987_v3/tests/test_parse_miles.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from x987.utils.text import parse_miles
+
+@pytest.mark.parametrize(
+    'src,expected',
+    [
+        ('52,123 miles', 52123),
+        ('52k miles', 52000),
+        ('1.5k mi', 1500),
+        ('no miles here', None),
+    ],
+)
+def test_parse_miles(src, expected):
+    assert parse_miles(src) == expected

--- a/x987_v3/x987/utils/text.py
+++ b/x987_v3/x987/utils/text.py
@@ -2,7 +2,7 @@
 import re
 
 RE_PRICE = re.compile(r"\$?\s*([0-9][0-9,]{0,})(?:\.\d{2})?")
-RE_MILES = re.compile(r"([0-9][0-9,]{0,})\s*(?:miles?|mi\.?)\b", re.I)
+RE_MILES = re.compile(r"([0-9][0-9,]*(?:\.\d+)?)\s*(k)?\s*(?:miles?|mi\.?)\b", re.I)
 RE_YEAR  = re.compile(r"\b(19|20)\d{2}\b")
 RE_VIN   = re.compile(r"\b([A-HJ-NPR-Z0-9]{17})\b")
 
@@ -11,5 +11,16 @@ def parse_price(s: str):
     return int(m.group(1).replace(",", "")) if m else None
 
 def parse_miles(s: str):
+    """Extract mileage in miles from a string.
+
+    Supports numbers with optional comma separators and values with a
+    ``k`` suffix (e.g. ``"52k miles"`` or ``"1.5k mi"``).  Returns ``None``
+    when no mileage figure can be detected.
+    """
     m = RE_MILES.search(s or "")
-    return int(m.group(1).replace(",", "")) if m else None
+    if not m:
+        return None
+    num = float(m.group(1).replace(",", ""))
+    if m.group(2):
+        num *= 1000
+    return int(num)


### PR DESCRIPTION
## Summary
- improve mileage parsing to understand values like `52k miles`
- add regression tests for mileage parsing

## Testing
- `pytest x987_v3/tests/test_parse_miles.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a603699924832887bfe806bb69a69c