### PR TITLE
Implement option-driven transform pipeline with color buckets

### DIFF
--- a/x987_v3/tests/test_transform.py
+++ b/x987_v3/tests/test_transform.py
@@ -1,0 +1,24 @@
+import options_v2
+from x987.pipeline.transform import run_transform
+
+
+def test_run_transform_normalizes_and_maps_options(monkeypatch):
+    monkeypatch.setattr(options_v2, "OPTIONS", {
+        "Sport Chrono": ["Sport Chrono Package"],
+        "Heated Seats": ["Seat Heating"],
+    })
+    rows = [{
+        "transmission_raw": "7-speed PDK dual clutch",
+        "exterior_color": "Agate Gray Metallic",
+        "interior_color": "Tan Leather",
+        "trim": "Sport Chrono Package",
+        "raw_options": ["Seat Heating"],
+    }]
+    transformed = run_transform(rows, {})
+    r = transformed[0]
+    assert r["transmission"] == "PDK"
+    assert r["exterior_color_bucket"] == "Gray"
+    assert r["interior_color_bucket"] == "Brown"
+    assert set(r["raw_options"]) == {"Sport Chrono Package", "Seat Heating"}
+    assert set(r["options"]) == {"Sport Chrono", "Heated Seats"}
+

--- a/x987_v3/x987/pipeline/transform.py
+++ b/x987_v3/x987/pipeline/transform.py
@@ -1,5 +1,72 @@
 from __future__ import annotations
 from typing import List, Dict
-# TODO: import options_v2 and apply detection; placeholder passthrough
+import re
+import options_v2
+
+TX_MAP = [
+    (r"(?i)\bPDK\b|dual[- ]clutch|dct|doppelkupplung|7[- ]speed(?:\s*pdk)?", "PDK"),
+    (r"(?i)\bTiptronic\b|automatic|auto\b|a/t", "Automatic"),
+    (r"(?i)\bmanual\b|6[- ]speed|6mt", "Manual"),
+]
+
+COLOR_BUCKETS = [
+    (r"(?i)black", "Black"),
+    (r"(?i)white|ivory", "White"),
+    (r"(?i)silver|gray|grey", "Gray"),
+    (r"(?i)red", "Red"),
+    (r"(?i)blue", "Blue"),
+    (r"(?i)green", "Green"),
+    (r"(?i)yellow|gold", "Yellow"),
+    (r"(?i)orange", "Orange"),
+    (r"(?i)brown|tan|beige", "Brown"),
+    (r"(?i)purple", "Purple"),
+]
+
+
+def _norm_transmission(tx_raw: str | None) -> str | None:
+    if not tx_raw:
+        return None
+    for pat, label in TX_MAP:
+        if re.search(pat, tx_raw):
+            return label
+    return tx_raw.strip()
+
+
+def _color_bucket(color: str | None) -> str | None:
+    if not color:
+        return None
+    for pat, bucket in COLOR_BUCKETS:
+        if re.search(pat, color):
+            return bucket
+    return "Other"
+
+
 def run_transform(rows: List[Dict], settings: dict) -> List[Dict]:
+    option_aliases = getattr(options_v2, "OPTIONS", {})
+    for row in rows:
+        row["transmission"] = _norm_transmission(row.get("transmission_raw"))
+        row["exterior_color_bucket"] = _color_bucket(row.get("exterior_color"))
+        row["interior_color_bucket"] = _color_bucket(row.get("interior_color"))
+
+        text_parts = []
+        for key in ("trim", "model"):
+            val = row.get(key)
+            if val:
+                text_parts.append(str(val))
+        raw = row.get("raw_options")
+        if isinstance(raw, list):
+            text_parts.extend(str(v) for v in raw if v)
+        elif raw:
+            text_parts.append(str(raw))
+        blob = " ".join(text_parts).lower()
+
+        raw_opts = set()
+        opts = set()
+        for canon, aliases in option_aliases.items():
+            for alias in aliases:
+                if alias.lower() in blob:
+                    raw_opts.add(alias)
+                    opts.add(canon)
+        row["raw_options"] = sorted(raw_opts) if raw_opts else None
+        row["options"] = sorted(opts) if opts else None
     return rows


### PR DESCRIPTION
## Summary
- Normalize transmissions and derive exterior/interior color buckets
- Map raw option aliases to canonical names using options_v2.OPTIONS
- Add tests covering transmission normalization, color bucketing, and option mapping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a60c00d0008328921e2762e5e0d105