### PR TITLE
Add mileage-adjusted pricing and ranking pipeline

### DIFF
--- a/x987_v3/x987/pipeline/baseline.py
+++ b/x987_v3/x987/pipeline/baseline.py
@@ -1,4 +1,38 @@
-﻿from __future__ import annotations
-from typing import List, Dict
+"""Baseline median computation for adjusted prices.
+
+The *baseline* stage groups cars by year and trim and calculates the median of
+the ``adj_price_usd`` field for each group.  The resulting median is stored in
+``baseline_adj_price_usd`` on each row so that later stages can quantify how
+far a particular listing deviates from the typical price for its peers.
+"""
+
+from __future__ import annotations
+
+from statistics import median
+from typing import Dict, List, Tuple
+
+
+def _group_key(row: Dict) -> Tuple[str, str]:
+    """Return the grouping key used for baseline medians."""
+
+    year = str(row.get("year") or "").strip()
+    trim = str(row.get("trim") or "").strip()
+    return year, trim
+
+
 def run_baseline(rows: List[Dict], settings: dict) -> List[Dict]:
+    """Attach ``baseline_adj_price_usd`` medians for each (year, trim) group."""
+
+    groups: Dict[Tuple[str, str], List[int]] = {}
+    for r in rows:
+        adj = r.get("adj_price_usd")
+        if isinstance(adj, (int, float)):
+            groups.setdefault(_group_key(r), []).append(int(adj))
+
+    medians = {k: int(median(v)) for k, v in groups.items() if v}
+
+    for r in rows:
+        r["baseline_adj_price_usd"] = medians.get(_group_key(r))
+
     return rows
+

--- a/x987_v3/x987/pipeline/fairvalue.py
+++ b/x987_v3/x987/pipeline/fairvalue.py
@@ -1,4 +1,65 @@
-﻿from __future__ import annotations
-from typing import List, Dict
+"""Mileage based price normalisation.
+
+This module implements the *fair value* stage of the pipeline.  Each input row
+is expected to contain at least ``price_usd`` and optionally ``mileage``.  The
+stage adds an ``adj_price_usd`` field representing the price adjusted to a
+baseline mileage.  The calculation is intentionally simple but provides stable
+figures for subsequent stages (baseline and ranking) to operate on.
+
+The adjustment formula mirrors the v2 "dollar" model used by previous versions
+of the project::
+
+    adj_price = price_usd + (mileage - baseline_miles) * usd_per_mile
+
+``baseline_miles`` defaults to ``50_000`` and ``usd_per_mile`` to ``0.20`` but
+both can be overridden via ``settings['fairvalue']``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from ..utils.text import parse_miles, parse_price
+
+
+def _to_int(val: object, parser) -> int | None:
+    """Coerce ``val`` to ``int`` using ``parser`` for strings.
+
+    ``parser`` should accept a string and return an ``int`` or ``None``.  Any
+    error results in ``None``.
+    """
+
+    if isinstance(val, (int, float)):
+        return int(val)
+    if val is None:
+        return None
+    try:
+        parsed = parser(str(val))
+        return int(parsed) if parsed is not None else None
+    except Exception:
+        return None
+
+
 def run_fairvalue(rows: List[Dict], settings: dict) -> List[Dict]:
+    """Compute ``adj_price_usd`` for each row and return the updated list."""
+
+    fv_cfg = settings.get("fairvalue", {}) if isinstance(settings, dict) else {}
+    base_miles = fv_cfg.get("baseline_miles", 50_000)
+    usd_per_mile = fv_cfg.get("usd_per_mile", 0.20)
+
+    for r in rows:
+        price = _to_int(r.get("price_usd"), parse_price)
+        miles = _to_int(r.get("mileage"), parse_miles)
+
+        if price is None:
+            r["adj_price_usd"] = None
+            continue
+
+        adj_price = float(price)
+        if miles is not None:
+            adj_price += (miles - base_miles) * float(usd_per_mile)
+
+        r["adj_price_usd"] = int(round(adj_price))
+
     return rows
+

--- a/x987_v3/x987/pipeline/rank.py
+++ b/x987_v3/x987/pipeline/rank.py
@@ -1,4 +1,34 @@
-﻿from __future__ import annotations
-from typing import List, Dict
+"""Ranking stage for the v2 dollar model.
+
+This final stage computes a ``deal_delta`` for each row – the difference
+between the ``baseline_adj_price_usd`` and the row's ``adj_price_usd`` – and
+returns the rows sorted by that delta (largest positive deltas first).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+
 def run_rank(rows: List[Dict], settings: dict) -> List[Dict]:
-    return rows
+    """Calculate deal deltas and sort results.
+
+    ``deal_delta`` is the baseline adjusted price minus the row's adjusted
+    price.  Listings with the highest positive deltas are considered better
+    deals and therefore appear first in the returned list.
+    """
+
+    for r in rows:
+        adj = r.get("adj_price_usd")
+        baseline = r.get("baseline_adj_price_usd")
+        if isinstance(adj, (int, float)) and isinstance(baseline, (int, float)):
+            r["deal_delta"] = int(baseline - adj)
+        else:
+            r["deal_delta"] = None
+
+    return sorted(
+        rows,
+        key=lambda r: r.get("deal_delta", float("-inf")),
+        reverse=True,
+    )
+


### PR DESCRIPTION
## Summary
- compute mileage-adjusted fair value prices
- derive baseline medians per year/trim and deltas
- rank listings by deal delta

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a60c06798483289a5e2516b8dbd0d2