### PR TITLE
Capture raw transmission and parse listing options

### DIFF
--- a/build_x987_v3.ps1
+++ b/build_x987_v3.ps1
@@ -164,7 +164,7 @@ def doctor_check() -> None:
 Write-Utf8 (Join-Path $pkg "schema.py") @"
 from __future__ import annotations
 from dataclasses import dataclass, asdict
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any, Optional
 
 @dataclass
 class Row:
@@ -179,7 +179,7 @@ class Row:
     price_usd: Optional[int] = None
     exterior_color: Optional[str] = None
     interior_color: Optional[str] = None
-    raw_options: Optional[List[str]] = None
+    raw_options: Optional[str] = None
     location: Optional[str] = None
     error: Optional[str] = None
 

--- a/x987_v3/tests/test_transform.py
+++ b/x987_v3/tests/test_transform.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from x987.utils.text import detect_transmission, normalize_transmission
+from x987.scrapers.universal_vdp import _extract_options
+from x987.pipeline.transform import run_transform
+
+
+def test_detect_and_normalize_transmission():
+    txt = "This car has a 7-speed PDK gearbox"
+    raw = detect_transmission(txt)
+    assert raw == "7-speed PDK"
+    rows = run_transform([{ "transmission_raw": raw }], {})
+    assert rows[0]["transmission_raw"] == "PDK"
+
+
+def test_extract_options():
+    body = "Features:\n• Sport Chrono Package\n• Bose Audio\n- Heated Seats"
+    opts = _extract_options(body)
+    assert opts == "Sport Chrono Package; Bose Audio; Heated Seats"
+
+
+def test_run_transform_parses_options_string():
+    rows = run_transform([{ "raw_options": "First Option\nSecond Option" }], {})
+    assert rows[0]["raw_options"] == "First Option; Second Option"
+

--- a/x987_v3/x987/pipeline/transform.py
+++ b/x987_v3/x987/pipeline/transform.py
@@ -1,5 +1,25 @@
 from __future__ import annotations
+import re
 from typing import List, Dict
-# TODO: import options_v2 and apply detection; placeholder passthrough
+
+from ..utils.text import normalize_transmission
+
+
 def run_transform(rows: List[Dict], settings: dict) -> List[Dict]:
-    return rows
+    out: List[Dict] = []
+    for r in rows:
+        tx = normalize_transmission(r.get("transmission_raw"))
+        if tx:
+            r["transmission_raw"] = tx
+
+        opts = r.get("raw_options")
+        if isinstance(opts, list):
+            parts = [p.strip() for p in opts if p and p.strip()]
+            r["raw_options"] = "; ".join(parts) if parts else None
+        elif isinstance(opts, str):
+            parts = [p.strip() for p in re.split(r"[\n;]+", opts) if p.strip()]
+            r["raw_options"] = "; ".join(parts) if parts else None
+
+        out.append(r)
+    return out
+

--- a/x987_v3/x987/schema.py
+++ b/x987_v3/x987/schema.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass, asdict
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any, Optional
+
 
 @dataclass
 class Row:
@@ -15,9 +16,10 @@ class Row:
     price_usd: Optional[int] = None
     exterior_color: Optional[str] = None
     interior_color: Optional[str] = None
-    raw_options: Optional[List[str]] = None
+    raw_options: Optional[str] = None
     location: Optional[str] = None
     error: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
+

--- a/x987_v3/x987/utils/text.py
+++ b/x987_v3/x987/utils/text.py
@@ -1,14 +1,17 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 import re
+from typing import Optional
 
 RE_PRICE = re.compile(r"\$?\s*([0-9][0-9,]{0,})(?:\.\d{2})?")
 RE_MILES = re.compile(r"([0-9][0-9,]*(?:\.\d+)?)\s*(k)?\s*(?:miles?|mi\.?)\b", re.I)
 RE_YEAR  = re.compile(r"\b(19|20)\d{2}\b")
 RE_VIN   = re.compile(r"\b([A-HJ-NPR-Z0-9]{17})\b")
 
+
 def parse_price(s: str):
     m = RE_PRICE.search(s or "")
     return int(m.group(1).replace(",", "")) if m else None
+
 
 def parse_miles(s: str):
     """Extract mileage in miles from a string.
@@ -24,3 +27,34 @@ def parse_miles(s: str):
     if m.group(2):
         num *= 1000
     return int(num)
+
+
+# transmission helpers -----------------------------------------------------
+
+TX_MAP = [
+    (r"(?i)7[- ]speed(?:\s*pdk)?|\bPDK\b|dual[- ]clutch|dct|doppelkupplung", "PDK"),
+    (r"(?i)Tiptronic|automatic|auto\b|a/t", "Automatic"),
+    (r"(?i)6[- ]speed|6mt|manual", "Manual"),
+]
+
+
+def detect_transmission(text: str) -> Optional[str]:
+    """Return the raw transmission string detected in ``text``."""
+    if not text:
+        return None
+    for pat, _ in TX_MAP:
+        m = re.search(pat, text)
+        if m:
+            return m.group(0)
+    return None
+
+
+def normalize_transmission(text: str) -> Optional[str]:
+    """Normalize ``text`` to a canonical transmission label."""
+    if not text:
+        return None
+    for pat, label in TX_MAP:
+        if re.search(pat, text):
+            return label
+    return None
+


### PR DESCRIPTION
## Summary
- detect and normalize transmission strings separately so raw text is scraped and normalized during transform
- scrape bullet-style feature text into a semicolon-separated `raw_options`
- add tests for transmission normalization and option parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a60c1ab5ac8328a59346572486f7ee