### PR TITLE
feat: add expanded option aliases

### DIFF
--- a/x987_v3/options_v2.py
+++ b/x987_v3/options_v2.py
@@ -1,5 +1,108 @@
-# Authoritative expanded options mapping lives here (placeholder).
+"""Expanded option aliases for transform normalization.
+
+Each key is a canonical option name.  The value lists representative
+synonyms or variants that may appear in listing data so the transform
+step can normalize them to the canonical label.
+"""
+
+# Authoritative expanded options mapping lives here.
+# Synonym lists are not exhaustive—just the common phrases we expect to
+# encounter in scraped data.
 OPTIONS = {
-  # Example:
-  # "Sport Chrono": ["Sport Chrono Package", "Sport Chrono Plus"],
+    # Sport Chrono package variants
+    "Sport Chrono": [
+        "Sport Chrono Package",
+        "Sport Chrono Package Plus",
+        "Sport Chrono Plus",
+    ],
+
+    # Porsche Active Suspension Management
+    "PASM": [
+        "PASM",
+        "Porsche Active Suspension Management",
+        "Active Suspension Management",
+        "Electronic Damper Control",
+    ],
+
+    # Porsche Sport Exhaust system
+    "Porsche Sport Exhaust": [
+        "Porsche Sport Exhaust",
+        "Sport Exhaust System",
+        "Sport Exhaust",
+        "PSE",
+    ],
+
+    # Limited slip differential
+    "Limited Slip Differential": [
+        "Limited Slip Differential",
+        "LSD",
+        "Rear Differential Lock",
+    ],
+
+    # Porsche Ceramic Composite Brakes
+    "PCCB": [
+        "PCCB",
+        "Porsche Ceramic Composite Brakes",
+        "Ceramic Brakes",
+        "Carbon Ceramic Brakes",
+    ],
+
+    # Bose premium audio
+    "Bose Audio": [
+        "Bose Audio",
+        "Bose Surround Sound",
+        "Bose High End Sound",
+        "Bose Premium Audio",
+    ],
+
+    # PCM navigation system
+    "PCM Navigation": [
+        "PCM Navigation",
+        "Porsche Communication Management",
+        "Navigation Module",
+        "Navigation System",
+        "PCM",
+        "Nav System",
+    ],
+
+    # Seat heating
+    "Heated Seats": [
+        "Heated Seats",
+        "Seat Heating",
+        "Heated Front Seats",
+        "Seat Heater",
+    ],
+
+    # Seat ventilation / cooling
+    "Ventilated Seats": [
+        "Ventilated Seats",
+        "Seat Ventilation",
+        "Cooled Seats",
+        "Seat Cooling",
+    ],
+
+    # Porsche Dynamic Light System
+    "PDLS": [
+        "PDLS",
+        "Porsche Dynamic Light System",
+        "Dynamic Light System",
+        "Dynamic Lighting",
+    ],
+
+    # Xenon / Bi-Xenon headlights
+    "Xenon Headlights": [
+        "Xenon Headlights",
+        "Bi-Xenon Headlights",
+        "Bi-Xenon",
+        "HID Headlights",
+    ],
+
+    # Sport seat variants
+    "Sport Seats": [
+        "Sport Seats",
+        "Sport Seat",
+        "Adaptive Sport Seats",
+        "Sport Seats Plus",
+    ],
 }
+


### PR DESCRIPTION
## Summary
- populate canonical option groups in options_v2
- document common synonyms for features like Sport Chrono, PASM, and more

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6182c9e888328b8b510af4608fa0c